### PR TITLE
fix: README内のreveal.js typoを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Markdownでスライド書いて、自分のGitHubで管理して、自分のGit
 
 ### add slide
 - Markdownでスライドを書く
-  - 書き方は[検索](https://www.google.com/search?q=revelal.js+markdown)するか、[サンプル](https://raw.githubusercontent.com/yamap55/SlideWithGitHubPages/master/example/slide1.md)見てください。
+  - 書き方は[検索](https://www.google.com/search?q=reveal.js+markdown)するか、[サンプル](https://raw.githubusercontent.com/yamap55/SlideWithGitHubPages/master/example/slide1.md)見てください。
 - GitHubにpush
 - 以下にアクセス
   - http://${userId}.github.io/${repositoryName}/index.html?slide=${markdownPath}


### PR DESCRIPTION
## 概要
README.md の「add slide」セクションにある検索リンク内で、`reveal.js` が `revelal.js` とtypoしていたため修正しました。

## 変更内容
- 23行目の検索リンク `https://www.google.com/search?q=revelal.js+markdown` を `reveal.js+markdown` に修正
  - 余分な `l` が入っており、読み手がGoogle検索する際に正しい結果が得られない状態でした

## 影響範囲
- ドキュメントのみ（コード・挙動への影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔁 Resume session: `claude -r 205ddaa3-d2f0-4884-b046-b970c1f3f22d`