### PR TITLE
chore: reveal.js を 3.5.0 から 6.0.1 へアップグレード

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Markdownでスライド書いて、自分のGitHubで管理して、自分のGit
 
 ## Description
 - Slideを作る際に、Markdownで書いて自分のGitHubで管理するして、自分のGitHub Pagesで表示できます
-  - reveal.js version 3.5.0を使用（[index.html](https://raw.githubusercontent.com/hakimel/reveal.js/a6ecbfa73272977d04e107f878a6afbfd17c6869/index.html)でリクエストパラメーターで渡されたスライドを表示できるようにしただけ）
+  - reveal.js version 6.0.1を使用（[index.html](https://raw.githubusercontent.com/hakimel/reveal.js/a6ecbfa73272977d04e107f878a6afbfd17c6869/index.html)でリクエストパラメーターで渡されたスライドを表示できるようにしただけ）
 - 通常、reveal.jsを使用する場合、毎回HTML部が必要となりますが、リクエストパラメーターでMarkdownのパスを指定すればスライドが表示されるようにしています
 
 ## Demo

--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
     <title>reveal.js</title>
     <link rel="icon" href="favicon.ico">
 
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/css/reveal.css">
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/css/theme/black.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/6.0.1/reveal.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/6.0.1/theme/black.min.css">
 
     <!-- Theme used for syntax highlighting of code -->
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/lib/css/zenburn.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/6.0.1/plugin/highlight/zenburn.min.css">
 
     <script>
       // リクエストパラメータを取得
@@ -39,14 +39,9 @@
         document.getElementById("slide").dataset.markdown = markdownUrl;
 
         Reveal.initialize({
-          dependencies: [
-            { src: "//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/plugin/markdown/marked.js" },
-            { src: "//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/plugin/markdown/markdown.min.js" },
-            { src: "//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/plugin/notes/notes.min.js", async: true },
-            { src: "//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/plugin/highlight/highlight.min.js", async: true, callback: function() { hljs.initHighlighting(); } }
-          ]
-        }, false);
-        Reveal.addEventListener("ready", (event) => {
+          plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ]
+        });
+        Reveal.on("ready", (event) => {
           // タイトル設定
           document.title = document.getElementsByTagName("h1")[0].innerText;
 
@@ -68,14 +63,6 @@
       });
       </script>
 
-    <!-- Printing and PDF exports -->
-    <script>
-      var link = document.createElement( "link" );
-      link.rel = "stylesheet";
-      link.type = "text/css";
-      link.href = window.location.search.match( /print-pdf/gi ) ? "//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/css/print/pdf.min.css" : "//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/css/print/paper.css";
-      document.getElementsByTagName( "head" )[0].appendChild(link);
-    </script>
     <style type="text/css">
       /* タイトルの大文字変換を無効 */
       .reveal h1,
@@ -94,7 +81,9 @@
         <section data-separator="^\r?\n---\r?\n$" data-separator-vertical="^\r?\n--\r?\n$" id="slide" />
       </div>
     </div>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/lib/js/head.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0/js/reveal.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/6.0.1/reveal.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/6.0.1/plugin/markdown.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/6.0.1/plugin/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/6.0.1/plugin/notes.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 概要

reveal.js を 3.5.0 から最新安定版 6.0.1 へアップグレードします。

姉妹リポジトリ [yamap55/Slide #110](https://github.com/yamap55/Slide/pull/110) と同等の修正を、本リポジトリの構成に合わせて適用しました。

方針:

- 追従先: 6.0.1
- 読み込み方式: CDN（cdnjs）を維持（npm/ビルド構成へは移行しない）
- 汎用ビューア方式（`?slide=YYYYMMDD/slide.md` で外部 Markdown を動的読み込み）を維持

改修は `index.html` のローダ部分に閉じており、スライド資産（`.md`）は無改修です。

## 変更内容

### index.html（reveal.js 4.x 以降の破壊的変更へ追従）

- CDN アセットを 6.0.1 構成へ更新（cdnjs はファイル構成がフラット化されており `dist/` プレフィックスなし）
- プラグイン読み込みを `dependencies` 配列方式 → `plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ]` 方式へ移行
- 廃止された `head.min.js` / `marked.js` / `hljs.initHighlighting()` / `Reveal.initialize` の第2引数を削除
- イベント登録を `Reveal.addEventListener("ready", …)` → `Reveal.on("ready", …)` へ
- 6.x でコアに内蔵された印刷スタイルに伴い、手動の PDF/print CSS 読み込み（`pdf.min.css` / `paper.css`）を削除
- CDN 参照をプロトコル相対 URL（`//cdnjs…`）から `https://` 明示へ統一

### README.md

- reveal.js の使用バージョン記載を 3.5.0 → 6.0.1 へ更新

## 動作確認

- CDN 全アセットの実在確認（いずれも HTTP 200）
- 旧バージョン（3.5.0）・旧 API（`dependencies` / `Reveal.addEventListener` / `hljs.initHighlighting` / `head.min.js` / print CSS）の残存なし

---

🔁 Resume session: `claude -r 9a112236-25aa-4e25-8f04-52a3010b59b3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)